### PR TITLE
allow Composer to update dependencies to satisfy version requirements

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require --dev nextcloud/ocp:${{ matrix.server-versions }}
+          composer require --dev nextcloud/ocp:${{ matrix.server-versions }} --with-all-dependencies
           composer i
 
       - name: Run coding standards check


### PR DESCRIPTION
subj, currently CI is failing with this:

```
Your requirements could not be resolved to an installable set of packages.

Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires nextcloud/ocp dev-master -> satisfiable by nextcloud/ocp[dev-master].
    - nextcloud/ocp dev-master requires psr/log ^3.0.2 -> found psr/log[3.0.2] but the package is fixed to 1.1.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
  Problem 1
    - Root composer.json requires nextcloud/ocp dev-master -> satisfiable by nextcloud/ocp[dev-master].
    - nextcloud/ocp dev-master requires psr/log ^3.0.2 -> found psr/log[3.0.2] but the package is fixed to 1.1.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```