### PR TITLE
fix: skip of writing "dummySecret" to the AppConfig

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -56,6 +56,10 @@ class ConfigController extends Controller {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 		foreach ($values as $key => $value) {
+			if ($key === 'token' && $value === 'dummyToken') {
+				continue;  // Skip writing if 'token' equals 'dummyToken'
+			}
+
 			if (in_array($key, ['token', 'refresh_token']) && $value !== '') {
 				$value = $this->crypto->encrypt($value);
 			}
@@ -83,6 +87,10 @@ class ConfigController extends Controller {
 	 */
 	public function setAdminConfig(array $values): DataResponse {
 		foreach ($values as $key => $value) {
+			if (($key === 'client_secret' && $value === 'dummySecret') || ($key === 'token' && $value === 'dummyToken')) {
+				continue;  // Skip writing if 'client_secret' equals 'dummySecret' or 'token' equals 'dummyToken'
+			}
+
 			if (in_array($key, ['client_secret', 'token', 'refresh_token']) && $value !== '') {
 				$value = $this->crypto->encrypt($value);
 			}


### PR DESCRIPTION
Message from Marcel(https://github.com/nextcloud/integration_onedrive/pull/56#issuecomment-2461874777):

> We need to check whether the dummySecret is resubmitted and filter it out

This PR should fix an issue that could occasionally occur, which was introduced in a previous PR with configs being overwritten with incorrect values.