### PR TITLE
fix(fileRequest): use Guzzle's "sink" instead of stream

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -20,14 +20,10 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1']
-        server-versions: ['v27.x.x']
-        include:
-          - php-versions: '8.2'
-            server-versions: 'v28.x.x'
-          - php-versions: '8.3'
-            server-versions: 'dev-master'
+        php-versions: ['8.1', '8.2']
+        server-versions: ['v29.x.x', 'v30.x.x']
 
     name: Nextcloud
     steps:

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@
     <bugs>https://github.com/nextcloud/integration_onedrive/issues</bugs>
     <screenshot>https://github.com/nextcloud/integration_onedrive/raw/main/img/screenshot1.jpg</screenshot>
     <dependencies>
-        <nextcloud min-version="28" max-version="31"/>
+        <nextcloud min-version="29" max-version="32"/>
     </dependencies>
     <settings>
         <admin>OCA\Onedrive\Settings\Admin</admin>


### PR DESCRIPTION
I can reproduce locally such error(_I was able to reproduce this even a year ago, but I was thinking that it is only on my local machine_): 
`Allowed memory size of 536870912 bytes exhausted (tried to allocate 5000032 bytes) at /var/www/html/lib/private/Log/ExceptionSerializer.php#236`

After that always syncing dies, as process crashes and flag `onedrive_import_running` does not get reset in the database for the next background jobs run.

---
Why does memory error occur? (a guess)

The Nextcloud HTTP client is a thin wrapper around Guzzle 7.
With Guzzle, the `stream => true` flag does not stream the response to the passed resource; it only prevents the body from being-decoded, afaik.
The entire response is still buffered in memory before it is handed back as a `Psr7\Stream`.
When we then iterate over that stream with `fread()`, every 5 MB chunk we copy is duplicated – the buffered copy inside Guzzle plus your `$chunk` string – until PHP asks for another 5 MB and finally dies at ~512 MB.

The easiest way is to tell Guzzle to write directly to the file handler, with [sink](https://docs.guzzlephp.org/en/stable/request-options.html#sink)

I have tested this changes and now I do not see `memory exhausted` errors anymore.