### PR TITLE
fix(psalm): ensure correct response for 204 status

### DIFF
--- a/lib/Service/OnedriveAPIService.php
+++ b/lib/Service/OnedriveAPIService.php
@@ -169,6 +169,10 @@ class OnedriveAPIService {
 					}
 					return json_decode($body, true) ?: [];
 				} else {
+					if ($body === null) {
+						$body = '';
+					}
+					/** @var resource|string $body */
 					return [
 						'body' => $body,
 						'headers' => $response->getHeaders(),


### PR DESCRIPTION
After updating the Psalm and Nextcloud coding standards packages, we received a correct complaint from Psalm that a `request` function could return `null`.

This PR fixes that complain.