### PR TITLE
fix: bound stalled file downloads and keep download URLs out of the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.5.3]
+
+### Fixed
+
+- Stop a file import from blocking forever when a download stalls
+- Stop logging download URLs, they contain a short lived access token
+
 ## [3.5.2] - 2026-07-28
 
 ### Added

--- a/lib/Service/OnedriveAPIService.php
+++ b/lib/Service/OnedriveAPIService.php
@@ -28,6 +28,11 @@ use Throwable;
 
 class OnedriveAPIService {
 
+	/**
+	 * Give up on a file download that has transferred nothing for this many seconds.
+	 */
+	private const DOWNLOAD_STALL_TIMEOUT = 30;
+
 	private IClient $client;
 
 	private string $userAgent;
@@ -81,7 +86,15 @@ class OnedriveAPIService {
 		try {
 			$options = [
 				'sink' => $resource,
+				// No total transfer timeout, a big file may legitimately take a long time.
 				'timeout' => 0,
+				// A download URL that expired while the import was running can be accepted
+				// by the remote end without any data ever being sent. Without this the job
+				// would block on such a connection forever.
+				'curl' => [
+					CURLOPT_LOW_SPEED_LIMIT => 1,
+					CURLOPT_LOW_SPEED_TIME => self::DOWNLOAD_STALL_TIMEOUT,
+				],
 				'headers' => [
 					'User-Agent' => $this->userAgent,
 				],
@@ -96,15 +109,29 @@ class OnedriveAPIService {
 			}
 			return ['success' => true];
 		} catch (ServerException|ClientException $e) {
-			$this->logger->warning('OneDrive API error : ' . $e->getMessage(), ['app' => Application::APP_ID]);
-			return ['error' => $e->getMessage()];
+			$error = $this->withoutUrls($e->getMessage());
+			$this->logger->warning('OneDrive API error : ' . $error, ['app' => Application::APP_ID]);
+			return ['error' => $error];
 		} catch (ConnectException $e) {
-			$this->logger->error('OneDrive API request connection error: ' . $e->getMessage(), ['app' => Application::APP_ID]);
-			return ['error' => $e->getMessage()];
+			$error = $this->withoutUrls($e->getMessage());
+			$this->logger->error('OneDrive API request connection error: ' . $error, ['app' => Application::APP_ID]);
+			return ['error' => $error];
 		} catch (Exception|Throwable $e) {
-			$this->logger->error('OneDrive API request connection error: ' . $e->getMessage(), ['app' => Application::APP_ID]);
-			return ['error' => $e->getMessage()];
+			$error = $this->withoutUrls($e->getMessage());
+			$this->logger->error('OneDrive API request connection error: ' . $error, ['app' => Application::APP_ID]);
+			return ['error' => $error];
 		}
+	}
+
+	/**
+	 * Strip URLs out of an error message before it is logged or handed to the caller.
+	 *
+	 * Guzzle includes the requested URL in its exception messages. A OneDrive download
+	 * URL carries a short lived access token in its query string, so such a message must
+	 * never end up in the log, where it gets copied into bug reports.
+	 */
+	private function withoutUrls(string $message): string {
+		return preg_replace('/https?:\/\/\S+/', '<url removed>', $message) ?? $message;
 	}
 
 	/**


### PR DESCRIPTION
Related #139

The import job could block forever on a single file download, and the error it eventually produced leaked a credential into the log. Both are fixed here. The underlying trigger reported in #139 — that a `@microsoft.graph.downloadUrl` taken from a folder listing may already have expired by the time the loop reaches that file — is left for a follow-up PR.

### Download stalls are now bounded

`fileRequest()` passed `'timeout' => 0` and set no read bound, so a remote end that accepts the connection and then sends nothing blocks the job indefinitely: no timeout, no error, no log line, no heartbeat. The reporter saw an `ImportOnedriveJob` sit in that state for hours.

A download now aborts after 30 seconds without any data transferred. A total transfer timeout is deliberately not used, it would also kill legitimately long downloads of big files.

Worth flagging for review: Guzzle's `read_timeout`, the obvious candidate, does nothing here. It is only honoured by the stream handler, and Nextcloud's HTTP client uses cURL. With `read_timeout => 5` the request still blocked indefinitely; `CURLOPT_LOW_SPEED_*` aborts as expected.

The abort surfaces as a `ConnectException`, which `fileRequest()` already catches, so the existing handling in `getFile()` applies unchanged: the partial file is deleted and the import carries on.

### Download URLs are no longer logged

A OneDrive download URL carries a `tempauth` token in its query string. Guzzle puts the requested URL into its exception messages, and those messages were logged verbatim — in two places, once in `fileRequest()` and again in `getFile()`. Anyone attaching a log excerpt to a bug report, as the issue template asks them to, published a working credential for their own drive.

URLs are now stripped from the message before it is logged or returned to the caller, which covers both places.

### Testing

Tested against a local endpoint that accepts the connection and then sends nothing, calling the real `fileRequest()` with a URL carrying a canary token in a `tempauth` parameter:

| | before | after |
|---|---|---|
| silent peer | never returned, had to be killed | returns after 30.1s with an error |
| peer dies mid-transfer | canary token present in `nextcloud.log` | `<url removed>`, canary absent from the log |

`composer cs:check` and psalm both pass.
