### PR TITLE
fix: report files that could not be downloaded when the import finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Stop a file import from blocking forever when a download stalls
 - Stop logging download URLs, they contain a short lived access token
 - Retry a failed file download once with a freshly fetched download URL, the one from the folder listing may have expired during a long import
+- Report files that could not be downloaded in the import finished notification, which also no longer counts them as imported
 
 ## [3.5.2] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Stop a file import from blocking forever when a download stalls
 - Stop logging download URLs, they contain a short lived access token
 - Retry a failed file download once with a freshly fetched download URL, the one from the folder listing may have expired during a long import
-- Report files that could not be downloaded in the import finished notification, which also no longer counts them as imported
+- Report files that could not be downloaded in the import finished notification, with their names, which also no longer counts them as imported
+- Mention files that were already there in the import finished notification, so re-running an import does not look like a failure
+- Count imported empty files as imported
 
 ## [3.5.2] - 2026-07-28
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -82,12 +82,21 @@ class Notifier implements INotifier {
 
 		switch ($notification->getSubject()) {
 			case 'import_onedrive_finished':
-				/** @var array{nbImported?: string, nbFailed?: string, targetPath: string} $p */
+				/** @var array{nbImported?: string, nbFailed?: string, nbSkipped?: string, failedFiles?: string[], targetPath: string} $p */
 				$p = $notification->getSubjectParameters();
 				$nbImported = (int)($p['nbImported'] ?? 0);
 				$nbFailed = (int)($p['nbFailed'] ?? 0);
+				$nbSkipped = (int)($p['nbSkipped'] ?? 0);
+				$failedFiles = is_array($p['failedFiles'] ?? null) ? $p['failedFiles'] : [];
 				$targetPath = $p['targetPath'];
 				$content = $l->n('%n file was imported from OneDrive storage.', '%n files were imported from OneDrive storage.', $nbImported);
+				if ($nbSkipped > 0) {
+					$content .= ' ' . $l->n(
+						'%n file was already there.',
+						'%n files were already there.',
+						$nbSkipped
+					);
+				}
 				if ($nbFailed > 0) {
 					$content .= ' ' . $l->n(
 						'%n file could not be downloaded, check the server logs for details.',
@@ -96,6 +105,15 @@ class Notifier implements INotifier {
 					);
 				}
 
+				if ($failedFiles !== []) {
+					$names = implode(', ', $failedFiles);
+					$nbMore = $nbFailed - count($failedFiles);
+					$notification->setParsedMessage(
+						$nbMore > 0
+							? $l->t('Could not download: %1$s, and %2$s more', [$names, (string)$nbMore])
+							: $l->t('Could not download: %s', [$names])
+					);
+				}
 				$notification->setParsedSubject($content)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app-dark.svg')))
 					->setLink($this->url->linkToRouteAbsolute('files.view.index', ['dir' => $targetPath]));

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -82,11 +82,19 @@ class Notifier implements INotifier {
 
 		switch ($notification->getSubject()) {
 			case 'import_onedrive_finished':
-				/** @var array{nbImported?: string, targetPath: string} $p */
+				/** @var array{nbImported?: string, nbFailed?: string, targetPath: string} $p */
 				$p = $notification->getSubjectParameters();
 				$nbImported = (int)($p['nbImported'] ?? 0);
+				$nbFailed = (int)($p['nbFailed'] ?? 0);
 				$targetPath = $p['targetPath'];
 				$content = $l->n('%n file was imported from OneDrive storage.', '%n files were imported from OneDrive storage.', $nbImported);
+				if ($nbFailed > 0) {
+					$content .= ' ' . $l->n(
+						'%n file could not be downloaded, check the server logs for details.',
+						'%n files could not be downloaded, check the server logs for details.',
+						$nbFailed
+					);
+				}
 
 				$notification->setParsedSubject($content)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app-dark.svg')))

--- a/lib/Service/OnedriveStorageAPIService.php
+++ b/lib/Service/OnedriveStorageAPIService.php
@@ -129,6 +129,7 @@ class OnedriveStorageAPIService {
 		}
 		$this->config->setUserValue($userId, Application::APP_ID, 'importing_onedrive', '1');
 		$this->config->setUserValue($userId, Application::APP_ID, 'imported_size', '0');
+		$this->config->setUserValue($userId, Application::APP_ID, 'nb_failed_files', '0');
 		$this->config->setUserValue($userId, Application::APP_ID, 'last_onedrive_import_timestamp', '0');
 		$this->config->deleteUserValue($userId, Application::APP_ID, 'import_tree');
 
@@ -195,14 +196,19 @@ class OnedriveStorageAPIService {
 			];
 		}
 		if (isset($result['error']) || (isset($result['finished']) && $result['finished'])) {
+			// read the counters accumulated over all batches before resetting them
+			$nbImported = (int)$this->config->getUserValue($userId, Application::APP_ID, 'nb_imported_files', '0');
+			$nbFailed = (int)$this->config->getUserValue($userId, Application::APP_ID, 'nb_failed_files', '0');
 			$this->config->setUserValue($userId, Application::APP_ID, 'importing_onedrive', '0');
 			$this->config->setUserValue($userId, Application::APP_ID, 'imported_size', '0');
 			$this->config->setUserValue($userId, Application::APP_ID, 'nb_imported_files', '0');
+			$this->config->setUserValue($userId, Application::APP_ID, 'nb_failed_files', '0');
 			$this->config->setUserValue($userId, Application::APP_ID, 'last_onedrive_import_timestamp', '0');
 			if (isset($result['finished']) && $result['finished']) {
 				$this->config->deleteUserValue($userId, Application::APP_ID, 'import_tree');
 				$this->onedriveApiService->sendNCNotification($userId, 'import_onedrive_finished', [
-					'nbImported' => $result['totalSeenNumber'],
+					'nbImported' => $nbImported,
+					'nbFailed' => $nbFailed,
 					'targetPath' => $targetPath,
 				]);
 			}
@@ -335,6 +341,11 @@ class OnedriveStorageAPIService {
 						if ($maxDownloadSize !== null && $newDownloadedSize >= $maxDownloadSize) {
 							throw new MaxDownloadSizeReachedException('Download size limit reached');
 						}
+					} else {
+						// count files that could not be downloaded, to report them in the
+						// notification sent when the import finishes
+						$nbFailed = (int)$this->config->getUserValue($userId, Application::APP_ID, 'nb_failed_files', '0');
+						$this->config->setUserValue($userId, Application::APP_ID, 'nb_failed_files', (string)($nbFailed + 1));
 					}
 				}
 				// folders: remember for recursion

--- a/lib/Service/OnedriveStorageAPIService.php
+++ b/lib/Service/OnedriveStorageAPIService.php
@@ -39,6 +39,17 @@ use Throwable;
  */
 
 class OnedriveStorageAPIService {
+
+	private const FILE_DOWNLOADED = 'downloaded';
+	private const FILE_ALREADY_THERE = 'already there';
+	private const FILE_FAILED = 'failed';
+
+	/**
+	 * How many failed file names are kept to be shown in the import finished
+	 * notification. The full list is in the server log.
+	 */
+	private const MAX_REPORTED_FAILED_FILES = 10;
+
 	/**
 	 * @var string
 	 */
@@ -130,7 +141,9 @@ class OnedriveStorageAPIService {
 		$this->config->setUserValue($userId, Application::APP_ID, 'importing_onedrive', '1');
 		$this->config->setUserValue($userId, Application::APP_ID, 'imported_size', '0');
 		$this->config->setUserValue($userId, Application::APP_ID, 'nb_failed_files', '0');
+		$this->config->setUserValue($userId, Application::APP_ID, 'nb_skipped_files', '0');
 		$this->config->setUserValue($userId, Application::APP_ID, 'last_onedrive_import_timestamp', '0');
+		$this->config->deleteUserValue($userId, Application::APP_ID, 'failed_files');
 		$this->config->deleteUserValue($userId, Application::APP_ID, 'import_tree');
 
 		$this->jobList->add(ImportOnedriveJob::class, ['user_id' => $userId]);
@@ -199,16 +212,22 @@ class OnedriveStorageAPIService {
 			// read the counters accumulated over all batches before resetting them
 			$nbImported = (int)$this->config->getUserValue($userId, Application::APP_ID, 'nb_imported_files', '0');
 			$nbFailed = (int)$this->config->getUserValue($userId, Application::APP_ID, 'nb_failed_files', '0');
+			$nbSkipped = (int)$this->config->getUserValue($userId, Application::APP_ID, 'nb_skipped_files', '0');
+			$failedFiles = json_decode($this->config->getUserValue($userId, Application::APP_ID, 'failed_files', '[]'), true) ?: [];
 			$this->config->setUserValue($userId, Application::APP_ID, 'importing_onedrive', '0');
 			$this->config->setUserValue($userId, Application::APP_ID, 'imported_size', '0');
 			$this->config->setUserValue($userId, Application::APP_ID, 'nb_imported_files', '0');
 			$this->config->setUserValue($userId, Application::APP_ID, 'nb_failed_files', '0');
+			$this->config->setUserValue($userId, Application::APP_ID, 'nb_skipped_files', '0');
+			$this->config->deleteUserValue($userId, Application::APP_ID, 'failed_files');
 			$this->config->setUserValue($userId, Application::APP_ID, 'last_onedrive_import_timestamp', '0');
 			if (isset($result['finished']) && $result['finished']) {
 				$this->config->deleteUserValue($userId, Application::APP_ID, 'import_tree');
 				$this->onedriveApiService->sendNCNotification($userId, 'import_onedrive_finished', [
 					'nbImported' => $nbImported,
 					'nbFailed' => $nbFailed,
+					'nbSkipped' => $nbSkipped,
+					'failedFiles' => $failedFiles,
 					'targetPath' => $targetPath,
 				]);
 			}
@@ -325,27 +344,34 @@ class OnedriveStorageAPIService {
 				];
 			}
 
+			$pageSkipped = 0;
 			/** @var OneDriveItem $item */
 			foreach ($result['value'] as $item) {
 				if (isset($item['file'])) {
 					$newTotalSeenNumber++;
-					$size = $this->getFile($userId, $folder, $item);
-					if ($size !== null) {
-						$newDownloadedSize += $size;
-						if ($size > 0) {
-							$newNbDownloaded++;
-							$this->config->setUserValue($userId, Application::APP_ID, 'imported_size', (string)($alreadyImportedSize + $newDownloadedSize));
-							$this->config->setUserValue($userId, Application::APP_ID, 'nb_imported_files', (string)($alreadyImportedNumber + $newNbDownloaded));
-							$this->config->setUserValue($userId, Application::APP_ID, 'last_onedrive_import_timestamp', (string)(new \DateTime())->getTimestamp());
-						}
+					$fileResult = $this->getFile($userId, $folder, $item);
+					if ($fileResult['status'] === self::FILE_DOWNLOADED) {
+						$newDownloadedSize += $fileResult['size'];
+						$newNbDownloaded++;
+						$this->config->setUserValue($userId, Application::APP_ID, 'imported_size', (string)($alreadyImportedSize + $newDownloadedSize));
+						$this->config->setUserValue($userId, Application::APP_ID, 'nb_imported_files', (string)($alreadyImportedNumber + $newNbDownloaded));
+						$this->config->setUserValue($userId, Application::APP_ID, 'last_onedrive_import_timestamp', (string)(new \DateTime())->getTimestamp());
 						if ($maxDownloadSize !== null && $newDownloadedSize >= $maxDownloadSize) {
 							throw new MaxDownloadSizeReachedException('Download size limit reached');
 						}
+					} elseif ($fileResult['status'] === self::FILE_ALREADY_THERE) {
+						$pageSkipped++;
 					} else {
-						// count files that could not be downloaded, to report them in the
-						// notification sent when the import finishes
+						// count files that could not be downloaded and remember the first
+						// few names, to report them in the notification sent when the
+						// import finishes
 						$nbFailed = (int)$this->config->getUserValue($userId, Application::APP_ID, 'nb_failed_files', '0');
 						$this->config->setUserValue($userId, Application::APP_ID, 'nb_failed_files', (string)($nbFailed + 1));
+						if ($nbFailed < self::MAX_REPORTED_FAILED_FILES) {
+							$failedFiles = json_decode($this->config->getUserValue($userId, Application::APP_ID, 'failed_files', '[]'), true) ?: [];
+							$failedFiles[] = $item['name'];
+							$this->config->setUserValue($userId, Application::APP_ID, 'failed_files', json_encode($failedFiles));
+						}
 					}
 				}
 				// folders: remember for recursion
@@ -355,6 +381,11 @@ class OnedriveStorageAPIService {
 					$subPath = ltrim($path . '/' . $item['name']);
 					$importTree[$subPath] = 'todo';
 				}
+			}
+			if ($pageSkipped > 0) {
+				// one write per listing page, skipped files are frequent on re-imports
+				$nbSkipped = (int)$this->config->getUserValue($userId, Application::APP_ID, 'nb_skipped_files', '0');
+				$this->config->setUserValue($userId, Application::APP_ID, 'nb_skipped_files', (string)($nbSkipped + $pageSkipped));
 			}
 
 			// if this directory was marked unfinished, remove it now
@@ -431,17 +462,18 @@ class OnedriveStorageAPIService {
 	 * @param string $userId
 	 * @param Folder $folder
 	 * @param array $fileItem
-	 * @return ?float downloaded size, null if already existing or network error
+	 * @return array{status: string, size: float} status is one of the FILE_* constants,
+	 *                                            size is only meaningful for FILE_DOWNLOADED
 	 */
-	private function getFile(string $userId, Folder $folder, array $fileItem): ?float {
+	private function getFile(string $userId, Folder $folder, array $fileItem): array {
 		$fileName = $fileItem['name'];
 		try {
 			$fileExists = $folder->nodeExists($fileName);
 		} catch (ForbiddenException $e) {
-			return null;
+			return ['status' => self::FILE_FAILED, 'size' => 0.0];
 		}
 		if ($fileExists) {
-			return 0;
+			return ['status' => self::FILE_ALREADY_THERE, 'size' => 0.0];
 		}
 
 		$savedFile = $folder->newFile($fileName);
@@ -462,7 +494,7 @@ class OnedriveStorageAPIService {
 			if ($savedFile->isDeletable()) {
 				$savedFile->delete();
 			}
-			return null;
+			return ['status' => self::FILE_FAILED, 'size' => 0.0];
 		}
 
 		if (isset($fileItem['lastModifiedDateTime'])) {
@@ -473,7 +505,7 @@ class OnedriveStorageAPIService {
 			$savedFile->touch();
 		}
 		$stat = $savedFile->stat();
-		return (float)($stat['size'] ?? 0);
+		return ['status' => self::FILE_DOWNLOADED, 'size' => (float)($stat['size'] ?? 0)];
 	}
 
 	/**

--- a/tests/unit/Notification/NotifierTest.php
+++ b/tests/unit/Notification/NotifierTest.php
@@ -25,7 +25,9 @@ class NotifierTest extends TestCase {
 		parent::setUp();
 
 		$l = $this->createMock(IL10N::class);
-		$l->method('t')->willReturnArgument(0);
+		$l->method('t')->willReturnCallback(
+			static fn (string $text, $parameters = []) => vsprintf($text, is_array($parameters) ? $parameters : [$parameters])
+		);
 		$l->method('n')->willReturnCallback(
 			static fn (string $singular, string $plural, int $count) => str_replace('%n', (string)$count, $count === 1 ? $singular : $plural)
 		);
@@ -45,7 +47,7 @@ class NotifierTest extends TestCase {
 		);
 	}
 
-	private function prepare(array $subjectParameters, string $expectedSubject, string $subject = 'import_onedrive_finished', string $app = 'integration_onedrive'): void {
+	private function prepare(array $subjectParameters, string $expectedSubject, ?string $expectedMessage = null, string $subject = 'import_onedrive_finished', string $app = 'integration_onedrive'): void {
 		$notification = $this->createMock(INotification::class);
 		$notification->method('getApp')->willReturn($app);
 		$notification->method('getSubject')->willReturn($subject);
@@ -54,6 +56,14 @@ class NotifierTest extends TestCase {
 			->method('setParsedSubject')
 			->with($expectedSubject)
 			->willReturnSelf();
+		if ($expectedMessage === null) {
+			$notification->expects($this->never())->method('setParsedMessage');
+		} else {
+			$notification->expects($this->once())
+				->method('setParsedMessage')
+				->with($expectedMessage)
+				->willReturnSelf();
+		}
 		$notification->method('setIcon')->willReturnSelf();
 		$notification->method('setLink')->willReturnSelf();
 
@@ -69,17 +79,42 @@ class NotifierTest extends TestCase {
 
 	public function testFinishedWithFailures(): void {
 		$this->prepare(
-			['nbImported' => 5, 'nbFailed' => 2, 'targetPath' => '/OneDrive import'],
+			['nbImported' => 5, 'nbFailed' => 2, 'failedFiles' => ['a.jpg', 'b.jpg'], 'targetPath' => '/OneDrive import'],
 			'5 files were imported from OneDrive storage.'
-			. ' 2 files could not be downloaded, check the server logs for details.'
+			. ' 2 files could not be downloaded, check the server logs for details.',
+			'Could not download: a.jpg, b.jpg'
 		);
 	}
 
 	public function testFinishedWithSingleImportAndSingleFailure(): void {
 		$this->prepare(
-			['nbImported' => 1, 'nbFailed' => 1, 'targetPath' => '/OneDrive import'],
+			['nbImported' => 1, 'nbFailed' => 1, 'failedFiles' => ['a.jpg'], 'targetPath' => '/OneDrive import'],
 			'1 file was imported from OneDrive storage.'
-			. ' 1 file could not be downloaded, check the server logs for details.'
+			. ' 1 file could not be downloaded, check the server logs for details.',
+			'Could not download: a.jpg'
+		);
+	}
+
+	public function testFinishedWithMoreFailuresThanReportedNames(): void {
+		$this->prepare(
+			['nbImported' => 5, 'nbFailed' => 12, 'failedFiles' => ['a.jpg', 'b.jpg', 'c.jpg'], 'targetPath' => '/OneDrive import'],
+			'5 files were imported from OneDrive storage.'
+			. ' 12 files could not be downloaded, check the server logs for details.',
+			'Could not download: a.jpg, b.jpg, c.jpg, and 9 more'
+		);
+	}
+
+	public function testFinishedWithSkippedFiles(): void {
+		$this->prepare(
+			['nbImported' => 7, 'nbFailed' => 0, 'nbSkipped' => 1993, 'targetPath' => '/OneDrive import'],
+			'7 files were imported from OneDrive storage. 1993 files were already there.'
+		);
+	}
+
+	public function testRerunWithNothingNewExplainsItself(): void {
+		$this->prepare(
+			['nbImported' => 0, 'nbFailed' => 0, 'nbSkipped' => 2000, 'targetPath' => '/OneDrive import'],
+			'0 files were imported from OneDrive storage. 2000 files were already there.'
 		);
 	}
 

--- a/tests/unit/Notification/NotifierTest.php
+++ b/tests/unit/Notification/NotifierTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Onedrive\Tests;
+
+use InvalidArgumentException;
+use OCA\Onedrive\Notification\Notifier;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\TestCase;
+
+class NotifierTest extends TestCase {
+
+	private Notifier $notifier;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$l = $this->createMock(IL10N::class);
+		$l->method('t')->willReturnArgument(0);
+		$l->method('n')->willReturnCallback(
+			static fn (string $singular, string $plural, int $count) => str_replace('%n', (string)$count, $count === 1 ? $singular : $plural)
+		);
+		$factory = $this->createMock(IFactory::class);
+		$factory->method('get')->willReturn($l);
+
+		$url = $this->createMock(IURLGenerator::class);
+		$url->method('imagePath')->willReturn('img/app-dark.svg');
+		$url->method('getAbsoluteURL')->willReturn('http://nc.example.org/img/app-dark.svg');
+		$url->method('linkToRouteAbsolute')->willReturn('http://nc.example.org/apps/files');
+
+		$this->notifier = new Notifier(
+			$factory,
+			$this->createMock(IUserManager::class),
+			$this->createMock(INotificationManager::class),
+			$url,
+		);
+	}
+
+	private function prepare(array $subjectParameters, string $expectedSubject, string $subject = 'import_onedrive_finished', string $app = 'integration_onedrive'): void {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn($app);
+		$notification->method('getSubject')->willReturn($subject);
+		$notification->method('getSubjectParameters')->willReturn($subjectParameters);
+		$notification->expects($this->once())
+			->method('setParsedSubject')
+			->with($expectedSubject)
+			->willReturnSelf();
+		$notification->method('setIcon')->willReturnSelf();
+		$notification->method('setLink')->willReturnSelf();
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testFinishedWithoutFailures(): void {
+		$this->prepare(
+			['nbImported' => 5, 'nbFailed' => 0, 'targetPath' => '/OneDrive import'],
+			'5 files were imported from OneDrive storage.'
+		);
+	}
+
+	public function testFinishedWithFailures(): void {
+		$this->prepare(
+			['nbImported' => 5, 'nbFailed' => 2, 'targetPath' => '/OneDrive import'],
+			'5 files were imported from OneDrive storage.'
+			. ' 2 files could not be downloaded, check the server logs for details.'
+		);
+	}
+
+	public function testFinishedWithSingleImportAndSingleFailure(): void {
+		$this->prepare(
+			['nbImported' => 1, 'nbFailed' => 1, 'targetPath' => '/OneDrive import'],
+			'1 file was imported from OneDrive storage.'
+			. ' 1 file could not be downloaded, check the server logs for details.'
+		);
+	}
+
+	public function testNotificationQueuedBeforeUpgradeHasNoFailedCount(): void {
+		$this->prepare(
+			['nbImported' => 4, 'targetPath' => '/OneDrive import'],
+			'4 files were imported from OneDrive storage.'
+		);
+	}
+
+	public function testThrowsForOtherApp(): void {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('some_other_app');
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testThrowsForUnknownSubject(): void {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('integration_onedrive');
+		$notification->method('getSubject')->willReturn('some_unknown_subject');
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->notifier->prepare($notification, 'en');
+	}
+}

--- a/tests/unit/Service/OnedriveStorageAPIServiceTest.php
+++ b/tests/unit/Service/OnedriveStorageAPIServiceTest.php
@@ -82,7 +82,7 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 		);
 	}
 
-	private function getFile(array $fileItem): ?float {
+	private function getFile(array $fileItem): array {
 		$method = new ReflectionMethod(OnedriveStorageAPIService::class, 'getFile');
 		return $method->invoke($this->service, 'user1', $this->folder, $fileItem);
 	}
@@ -96,14 +96,14 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 			->willReturn(['success' => true]);
 		$this->apiService->expects($this->never())->method('getDownloadUrl');
 
-		$size = $this->getFile([
+		$result = $this->getFile([
 			'name' => 'photo.jpg',
 			'id' => 'item1',
 			'file' => [],
 			'@microsoft.graph.downloadUrl' => self::STALE_URL,
 		]);
 
-		$this->assertSame(123.0, $size);
+		$this->assertSame(['status' => 'downloaded', 'size' => 123.0], $result);
 	}
 
 	public function testFailedDownloadIsRetriedWithAFreshUrl(): void {
@@ -121,14 +121,14 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 			->with('user1', 'item1')
 			->willReturn(self::FRESH_URL);
 
-		$size = $this->getFile([
+		$result = $this->getFile([
 			'name' => 'photo.jpg',
 			'id' => 'item1',
 			'file' => [],
 			'@microsoft.graph.downloadUrl' => self::STALE_URL,
 		]);
 
-		$this->assertSame(123.0, $size);
+		$this->assertSame(['status' => 'downloaded', 'size' => 123.0], $result);
 		$this->assertSame([self::STALE_URL, self::FRESH_URL], $requestedUrls);
 	}
 
@@ -140,7 +140,7 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 		$this->file->method('isDeletable')->willReturn(true);
 		$this->file->expects($this->once())->method('delete');
 
-		$this->assertNull($this->getFile([
+		$this->assertSame(['status' => 'failed', 'size' => 0.0], $this->getFile([
 			'name' => 'photo.jpg',
 			'id' => 'item1',
 			'file' => [],
@@ -154,7 +154,7 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 		$this->file->method('isDeletable')->willReturn(true);
 		$this->file->expects($this->once())->method('delete');
 
-		$this->assertNull($this->getFile([
+		$this->assertSame(['status' => 'failed', 'size' => 0.0], $this->getFile([
 			'name' => 'photo.jpg',
 			'id' => 'item1',
 			'file' => [],
@@ -173,13 +173,27 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 			->with('user1', 'item1')
 			->willReturn(self::FRESH_URL);
 
-		$size = $this->getFile([
+		$result = $this->getFile([
 			'name' => 'note.one',
 			'id' => 'item1',
 			'file' => [],
 		]);
 
-		$this->assertSame(42.0, $size);
+		$this->assertSame(['status' => 'downloaded', 'size' => 42.0], $result);
+	}
+
+	public function testDownloadedEmptyFileCountsAsDownloaded(): void {
+		$this->file->method('stat')->willReturn(['size' => 0]);
+		$this->apiService->method('fileRequest')->willReturn(['success' => true]);
+
+		$result = $this->getFile([
+			'name' => 'empty.txt',
+			'id' => 'item1',
+			'file' => [],
+			'@microsoft.graph.downloadUrl' => self::STALE_URL,
+		]);
+
+		$this->assertSame(['status' => 'downloaded', 'size' => 0.0], $result);
 	}
 
 	public function testExistingFileIsNotDownloadedAgain(): void {
@@ -189,15 +203,16 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 		$this->apiService->expects($this->never())->method('fileRequest');
 
 		$method = new ReflectionMethod(OnedriveStorageAPIService::class, 'getFile');
-		$size = $method->invoke($this->service, 'user1', $folder, ['name' => 'photo.jpg']);
+		$result = $method->invoke($this->service, 'user1', $folder, ['name' => 'photo.jpg']);
 
-		$this->assertSame(0.0, $size);
+		$this->assertSame(['status' => 'already there', 'size' => 0.0], $result);
 	}
 
-	public function testImportCountsFailedDownloads(): void {
+	public function testImportCountsFailedSkippedAndEmptyDownloads(): void {
 		$this->useStatefulConfig([]);
 
-		// remote drive root holds three files, b fails on the listing URL and on a fresh one
+		// remote drive root holds four files: a succeeds, b fails on the listing URL
+		// and on a fresh one, c is an empty file, d already exists locally
 		$this->apiService->method('request')->willReturnCallback(
 			static function (string $userId, string $endPoint) {
 				if ($endPoint === 'me/drive') {
@@ -209,7 +224,7 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 						'id' => 'id-' . $name,
 						'file' => [],
 						'@microsoft.graph.downloadUrl' => 'https://listing.example.org/' . $name,
-					], ['a', 'b', 'c'])];
+					], ['a', 'b', 'c', 'd'])];
 				}
 				return [];
 			}
@@ -227,11 +242,13 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 			->willReturn('https://fresh.example.org/b');
 
 		$dirFolder = $this->createMock(Folder::class);
-		$dirFolder->method('nodeExists')->willReturn(false);
-		$dirFolder->method('newFile')->willReturnCallback(function () {
+		$dirFolder->method('nodeExists')->willReturnCallback(
+			static fn (string $name) => $name === 'd.jpg'
+		);
+		$dirFolder->method('newFile')->willReturnCallback(function (string $name) {
 			$file = $this->createMock(File::class);
 			$file->method('fopen')->willReturnCallback(static fn () => fopen('php://temp', 'w+'));
-			$file->method('stat')->willReturn(['size' => 10]);
+			$file->method('stat')->willReturn(['size' => $name === 'c.jpg' ? 0 : 10]);
 			$file->method('isDeletable')->willReturn(true);
 			return $file;
 		});
@@ -247,7 +264,11 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 
 		$this->assertTrue($result['finished']);
 		$this->assertSame('1', $this->configStore['nb_failed_files'] ?? null);
+		$this->assertSame('["b.jpg"]', $this->configStore['failed_files'] ?? null);
+		$this->assertSame('1', $this->configStore['nb_skipped_files'] ?? null);
+		// a and the empty file c are both imported
 		$this->assertSame('2', $this->configStore['nb_imported_files'] ?? null);
+		$this->assertSame('10', $this->configStore['imported_size'] ?? null);
 		$this->assertSame([
 			'https://listing.example.org/a',
 			'https://listing.example.org/b',
@@ -262,6 +283,8 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 			'onedrive_import_running' => '0',
 			'nb_imported_files' => '7',
 			'nb_failed_files' => '3',
+			'nb_skipped_files' => '5',
+			'failed_files' => '["x.jpg","y.jpg","z.jpg"]',
 		]);
 
 		// nothing left to download, the job finishes right away
@@ -287,6 +310,8 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 			->with('user1', 'import_onedrive_finished', [
 				'nbImported' => 7,
 				'nbFailed' => 3,
+				'nbSkipped' => 5,
+				'failedFiles' => ['x.jpg', 'y.jpg', 'z.jpg'],
 				'targetPath' => '/OneDrive import',
 			]);
 		$this->jobList->expects($this->never())->method('add');
@@ -295,6 +320,8 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 
 		$this->assertSame('0', $this->configStore['nb_imported_files']);
 		$this->assertSame('0', $this->configStore['nb_failed_files']);
+		$this->assertSame('0', $this->configStore['nb_skipped_files']);
+		$this->assertArrayNotHasKey('failed_files', $this->configStore);
 		$this->assertSame('0', $this->configStore['importing_onedrive']);
 	}
 }

--- a/tests/unit/Service/OnedriveStorageAPIServiceTest.php
+++ b/tests/unit/Service/OnedriveStorageAPIServiceTest.php
@@ -23,10 +23,16 @@ use ReflectionMethod;
 class OnedriveStorageAPIServiceTest extends TestCase {
 
 	private OnedriveAPIService|MockObject $apiService;
+	private IRootFolder|MockObject $rootFolder;
+	private IConfig|MockObject $config;
+	private IJobList|MockObject $jobList;
 	private Folder|MockObject $folder;
 	private File|MockObject $file;
 
 	private OnedriveStorageAPIService $service;
+
+	/** @var array<string, string> */
+	private array $configStore = [];
 
 	private const STALE_URL = 'https://stale.example.org/download?tempauth=old';
 	private const FRESH_URL = 'https://fresh.example.org/download?tempauth=new';
@@ -35,12 +41,15 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 		parent::setUp();
 
 		$this->apiService = $this->createMock(OnedriveAPIService::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->jobList = $this->createMock(IJobList::class);
 		$this->service = new OnedriveStorageAPIService(
 			'integration_onedrive',
 			$this->createMock(LoggerInterface::class),
-			$this->createMock(IRootFolder::class),
-			$this->createMock(IConfig::class),
-			$this->createMock(IJobList::class),
+			$this->rootFolder,
+			$this->config,
+			$this->jobList,
 			$this->createMock(UserScopeService::class),
 			$this->apiService,
 		);
@@ -50,6 +59,27 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 		$this->folder = $this->createMock(Folder::class);
 		$this->folder->method('nodeExists')->willReturn(false);
 		$this->folder->method('newFile')->willReturn($this->file);
+	}
+
+	/**
+	 * Back the IConfig mock with an array, so code doing read-increment-write
+	 * on user settings behaves like it does against the real config.
+	 */
+	private function useStatefulConfig(array $initial): void {
+		$this->configStore = $initial;
+		$this->config->method('getUserValue')->willReturnCallback(
+			fn (string $userId, string $appName, string $key, $default = '') => $this->configStore[$key] ?? $default
+		);
+		$this->config->method('setUserValue')->willReturnCallback(
+			function (string $userId, string $appName, string $key, $value): void {
+				$this->configStore[$key] = (string)$value;
+			}
+		);
+		$this->config->method('deleteUserValue')->willReturnCallback(
+			function (string $userId, string $appName, string $key): void {
+				unset($this->configStore[$key]);
+			}
+		);
 	}
 
 	private function getFile(array $fileItem): ?float {
@@ -162,5 +192,109 @@ class OnedriveStorageAPIServiceTest extends TestCase {
 		$size = $method->invoke($this->service, 'user1', $folder, ['name' => 'photo.jpg']);
 
 		$this->assertSame(0.0, $size);
+	}
+
+	public function testImportCountsFailedDownloads(): void {
+		$this->useStatefulConfig([]);
+
+		// remote drive root holds three files, b fails on the listing URL and on a fresh one
+		$this->apiService->method('request')->willReturnCallback(
+			static function (string $userId, string $endPoint) {
+				if ($endPoint === 'me/drive') {
+					return ['quota' => ['used' => 1000]];
+				}
+				if ($endPoint === 'me/drive/root/children') {
+					return ['value' => array_map(static fn (string $name) => [
+						'name' => $name . '.jpg',
+						'id' => 'id-' . $name,
+						'file' => [],
+						'@microsoft.graph.downloadUrl' => 'https://listing.example.org/' . $name,
+					], ['a', 'b', 'c'])];
+				}
+				return [];
+			}
+		);
+		$requestedUrls = [];
+		$this->apiService->method('fileRequest')->willReturnCallback(
+			static function (string $url) use (&$requestedUrls) {
+				$requestedUrls[] = $url;
+				return str_ends_with($url, '/b') ? ['error' => 'download error'] : ['success' => true];
+			}
+		);
+		$this->apiService->expects($this->once())
+			->method('getDownloadUrl')
+			->with('user1', 'id-b')
+			->willReturn('https://fresh.example.org/b');
+
+		$dirFolder = $this->createMock(Folder::class);
+		$dirFolder->method('nodeExists')->willReturn(false);
+		$dirFolder->method('newFile')->willReturnCallback(function () {
+			$file = $this->createMock(File::class);
+			$file->method('fopen')->willReturnCallback(static fn () => fopen('php://temp', 'w+'));
+			$file->method('stat')->willReturn(['size' => 10]);
+			$file->method('isDeletable')->willReturn(true);
+			return $file;
+		});
+		$topFolder = $this->createMock(Folder::class);
+		$topFolder->method('nodeExists')->willReturn(true);
+		$topFolder->method('get')->willReturn($dirFolder);
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('nodeExists')->willReturn(true);
+		$userFolder->method('get')->willReturn($topFolder);
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$result = $this->service->importFiles('user1', '/Import');
+
+		$this->assertTrue($result['finished']);
+		$this->assertSame('1', $this->configStore['nb_failed_files'] ?? null);
+		$this->assertSame('2', $this->configStore['nb_imported_files'] ?? null);
+		$this->assertSame([
+			'https://listing.example.org/a',
+			'https://listing.example.org/b',
+			'https://fresh.example.org/b',
+			'https://listing.example.org/c',
+		], $requestedUrls);
+	}
+
+	public function testFinishedNotificationReportsImportedAndFailedCounts(): void {
+		$this->useStatefulConfig([
+			'importing_onedrive' => '1',
+			'onedrive_import_running' => '0',
+			'nb_imported_files' => '7',
+			'nb_failed_files' => '3',
+		]);
+
+		// nothing left to download, the job finishes right away
+		$this->apiService->method('request')->willReturnCallback(
+			static function (string $userId, string $endPoint) {
+				if ($endPoint === 'me/drive') {
+					return ['quota' => ['used' => 1000]];
+				}
+				if ($endPoint === 'me/drive/root/children') {
+					return ['value' => []];
+				}
+				return [];
+			}
+		);
+		$folder = $this->createMock(Folder::class);
+		$folder->method('isShared')->willReturn(false);
+		$folder->method('nodeExists')->willReturn(true);
+		$folder->method('get')->willReturnSelf();
+		$this->rootFolder->method('getUserFolder')->willReturn($folder);
+
+		$this->apiService->expects($this->once())
+			->method('sendNCNotification')
+			->with('user1', 'import_onedrive_finished', [
+				'nbImported' => 7,
+				'nbFailed' => 3,
+				'targetPath' => '/OneDrive import',
+			]);
+		$this->jobList->expects($this->never())->method('add');
+
+		$this->service->importOnedriveJob('user1');
+
+		$this->assertSame('0', $this->configStore['nb_imported_files']);
+		$this->assertSame('0', $this->configStore['nb_failed_files']);
+		$this->assertSame('0', $this->configStore['importing_onedrive']);
 	}
 }


### PR DESCRIPTION
Closes #139

Final part, following #142 and #143: a file that failed to download even after the fresh-URL retry was dropped silently, and the completion notification counted it as imported — it reported `totalSeenNumber`, which increments before the download is attempted.

### What changes

- Download failures are counted in a `nb_failed_files` user setting, accumulated across import batches the same way `nb_imported_files` already works, and reset at import start and finish. The names of the first ten failed files are kept as well.
- The finish notification now reports the number of files **actually downloaded** (the accumulated imported counter, instead of the last batch's seen count) and, when there were failures, appends: *"N files could not be downloaded, check the server logs for details."* — with the kept file names in the notification body: *"Could not download: DSC02561.jpg, DSC02561_thumb.jpg, and 9 more"*. Users without server-log access see which files are missing; the full list is in the log (redacted since #142).
- Files skipped because they already existed are counted too (one config write per listing page, since skips are frequent on re-imports) and reported: *"1993 files were already there."* Re-running an import into an already-imported folder used to end with a notification claiming everything was imported again; with the corrected imported-count alone it would have read "0 files were imported", which looks like a failure — now it explains itself.
- Distinguishing downloaded / existing / failed outcomes properly in `getFile()` also fixes a pre-existing quirk where a successfully imported **empty** file was never counted as imported.
- Notifications queued before an upgrade carry none of the new parameters and render exactly as before.

With this, all four problems from #139 are addressed: the indefinite hang (#142), the token leak into logs (#142), the expired listing URL (#143), and unreported missing files (this PR).

### Tests

- The counters: an import over a mocked four-file drive (one success, one double-failure, one empty file, one already existing) asserts the failed/skipped/imported counters, the kept failed-file names, and the exact download attempt sequence.
- The finish path: a finishing job asserts the notification carries the accumulated counts and file names, and that all counters are reset afterwards.
- The notifier: rendered subject and body with zero, one, few and many failures (including the "and N more" overflow), the skipped-files sentence, the re-run case, the pre-upgrade notification without the new parameters, and the unknown app/subject error paths.

`composer cs:check`, psalm and the suite (22 tests) pass locally on NC 33 / PHP 8.3. All notification variants were additionally rendered live on a real NC 35 instance through the OCS API to verify the actual L10N output.
