### PR TITLE
fix: throw UnknownNotificationException for unknown notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Stop a file import from blocking forever when a download stalls
 - Stop logging download URLs, they contain a short lived access token
 - Retry a failed file download once with a freshly fetched download URL, the one from the folder listing may have expired during a long import
+- Stop logging a deprecation warning every time another app sends a notification
 
 ## [3.5.2] - 2026-07-28
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -7,7 +7,6 @@
 
 namespace OCA\Onedrive\Notification;
 
-use InvalidArgumentException;
 use OCA\Onedrive\AppInfo\Application;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -15,6 +14,7 @@ use OCP\L10N\IFactory;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 
@@ -69,13 +69,13 @@ class Notifier implements INotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws UnknownNotificationException When the notification was not prepared by a notifier
 	 * @since 9.0.0
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'integration_onedrive') {
 			// Not my app => throw
-			throw new InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		$l = $this->factory->get('integration_onedrive', $languageCode);
@@ -94,7 +94,7 @@ class Notifier implements INotifier {
 				return $notification;
 			default:
 				// Unknown subject => Unknown notification => throw
-				throw new InvalidArgumentException();
+				throw new UnknownNotificationException();
 		}
 	}
 }


### PR DESCRIPTION
`Notifier::prepare()` throws `\InvalidArgumentException` to signal a notification it does not know — both another app's notification and an unknown subject of its own. Since Nextcloud 30 the server treats that as deprecated and logs a warning for every such call:

> `OCA\Onedrive\Notification\Notifier::prepare() threw \InvalidArgumentException which is deprecated. Throw \OCP\Notification\UnknownNotificationException when the notification is not known to your notifier and otherwise handle all \InvalidArgumentException yourself.`

Every registered notifier is asked to prepare every notification, so an instance with this app enabled writes one of these lines for each notification any other app sends.

Both throws now use `OCP\Notification\UnknownNotificationException`. It extends `\InvalidArgumentException` and has existed since Nextcloud 30, below this app's `min-version` of 33, so callers catching the old type are unaffected.

Same change as nextcloud/integration_jira#162, nextcloud/integration_github#202 and nextcloud/integration_openai#376.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
